### PR TITLE
Fix adapter issues

### DIFF
--- a/integration_tests/dbt_date/macros/get_test_dates.sql
+++ b/integration_tests/dbt_date/macros/get_test_dates.sql
@@ -1,10 +1,10 @@
-{% macro sqlserver__get_test_week_of_year() -%}
+{% macro synapse__get_test_week_of_year() -%}
     {# who knows what T-SQL uses?! #}
     {# see: https://github.com/calogica/dbt-date/issues/25 #}
     {{ return([49,49]) }}
 {%- endmacro %}
 
-{% macro sqlserver__get_test_timestamps() -%}
+{% macro synapse__get_test_timestamps() -%}
     {{ return(['2021-06-07 07:35:20.000000 -07:00',
                 '2021-06-07 14:35:20.000000 +00:00']) }}
 {%- endmacro %}

--- a/integration_tests/dbt_utils/macros/limit_zero.sql
+++ b/integration_tests/dbt_utils/macros/limit_zero.sql
@@ -1,3 +1,3 @@
-{% macro sqlserver__limit_zero() %}
+{% macro synapse__limit_zero() %}
   {{ return('where 0=1') }} 
 {% endmacro %}

--- a/macros/dbt_audit_helper/compare_column_values.sql
+++ b/macros/dbt_audit_helper/compare_column_values.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__compare_column_values(a_query, b_query, primary_key, column_to_compare) -%}
+{% macro synapse__compare_column_values(a_query, b_query, primary_key, column_to_compare) -%}
 with a_query as (
     {{ a_query }}
 ),

--- a/macros/dbt_audit_helper/compare_queries.sql
+++ b/macros/dbt_audit_helper/compare_queries.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__compare_queries(a_query, b_query, primary_key=None, summarize=true) %}
+{% macro synapse__compare_queries(a_query, b_query, primary_key=None, summarize=true) %}
 
 with a as (
 

--- a/macros/dbt_audit_helper/compare_relation_columns.sql
+++ b/macros/dbt_audit_helper/compare_relation_columns.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__compare_relation_columns(a_relation, b_relation) %}
+{% macro synapse__compare_relation_columns(a_relation, b_relation) %}
 
 with a_cols as (
     {{ tsql_utils.sqlserver__get_columns_in_relation_sql(a_relation) }}
@@ -22,7 +22,7 @@ full outer join b_cols using (column_name)
 {% endmacro %}
 
 
-{% macro sqlserver__get_columns_in_relation_sql(relation) %}
+{% macro synapse__get_columns_in_relation_sql(relation) %}
   SELECT
             column_name,
             data_type,

--- a/macros/dbt_audit_helper/compare_relations.sql
+++ b/macros/dbt_audit_helper/compare_relations.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__compare_relations(a_relation, b_relation, exclude_columns=[], primary_key=None, summarize=true) %}
+{% macro synapse__compare_relations(a_relation, b_relation, exclude_columns=[], primary_key=None, summarize=true) %}
 
 {%- set a_columns = adapter.get_columns_in_relation(a_relation) -%}
 

--- a/macros/dbt_date/calendar_date/convert_timezones.sql
+++ b/macros/dbt_date/calendar_date/convert_timezones.sql
@@ -1,3 +1,3 @@
-{% macro sqlserver__convert_timezone(column, target_tz, source_tz) -%}
+{% macro synapse__convert_timezone(column, target_tz, source_tz) -%}
     CAST({{ column }} as {{ dbt.type_timestamp() }}) AT TIME ZONE '{{ source_tz }}' AT TIME ZONE '{{ target_tz }}'
 {%- endmacro -%}

--- a/macros/dbt_date/calendar_date/date_part.sql
+++ b/macros/dbt_date/calendar_date/date_part.sql
@@ -1,3 +1,3 @@
-{% macro sqlserver__date_part(datepart, date) -%}
+{% macro synapse__date_part(datepart, date) -%}
     datepart({{ datepart }}, {{ date }})
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/day_name.sql
+++ b/macros/dbt_date/calendar_date/day_name.sql
@@ -1,4 +1,4 @@
-{%- macro sqlserver__day_name(date, short) -%}
+{%- macro synapse__day_name(date, short) -%}
 {%- set f = 'ddd' if short else 'dddd' -%}
     format({{ date }}, '{{ f }}')
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/day_of_week.sql
+++ b/macros/dbt_date/calendar_date/day_of_week.sql
@@ -1,5 +1,5 @@
 
-{%- macro sqlserver__day_of_week(date, isoweek) -%}
+{%- macro synapse__day_of_week(date, isoweek) -%}
 
     {%- set dow = dbt_date.date_part('weekday', date) -%}
 

--- a/macros/dbt_date/calendar_date/from_unixtimestamp.sql
+++ b/macros/dbt_date/calendar_date/from_unixtimestamp.sql
@@ -1,4 +1,4 @@
-{%- macro sqlserver__from_unixtimestamp(epochs, format) -%}
+{%- macro synapse__from_unixtimestamp(epochs, format) -%}
     
     {%- if format == "seconds" -%}
     {%- set scale = "S" -%}

--- a/macros/dbt_date/calendar_date/iso_week_of_year.sql
+++ b/macros/dbt_date/calendar_date/iso_week_of_year.sql
@@ -1,3 +1,3 @@
-{%- macro sqlserver__iso_week_of_year(date) -%}
+{%- macro synapse__iso_week_of_year(date) -%}
 cast({{ dbt_date.date_part('iso_week', date) }} as {{ dbt.type_int() }}) 
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/iso_week_start.sql
+++ b/macros/dbt_date/calendar_date/iso_week_start.sql
@@ -1,3 +1,3 @@
-{%- macro sqlserver__iso_week_start(date) -%}
+{%- macro synapse__iso_week_start(date) -%}
     cast(dateadd(week, datediff(week, 0, dateadd(day, -1, {{date}})), 0) as date)
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/month_name.sql
+++ b/macros/dbt_date/calendar_date/month_name.sql
@@ -1,4 +1,4 @@
-{%- macro sqlserver__month_name(date, short) -%}
+{%- macro synapse__month_name(date, short) -%}
 {%- set f = 'MMM' if short else 'MMMM' -%}
     format({{ date }}, '{{ f }}')
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/to_unixtimestamp.sql
+++ b/macros/dbt_date/calendar_date/to_unixtimestamp.sql
@@ -1,3 +1,3 @@
-{%- macro sqlserver__to_unixtimestamp(timestamp) -%}
+{%- macro synapse__to_unixtimestamp(timestamp) -%}
     DATEDIFF(s, '1970-01-01 00:00:00', {{ timestamp }})
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/week_end.sql
+++ b/macros/dbt_date/calendar_date/week_end.sql
@@ -1,4 +1,4 @@
-{%- macro sqlserver__week_end(date) -%}
+{%- macro synapse__week_end(date) -%}
 {%- set dt = dbt_date.week_start(date) -%}
 {{ dbt_date.n_days_away(6, dt) }}
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/week_of_year.sql
+++ b/macros/dbt_date/calendar_date/week_of_year.sql
@@ -1,3 +1,3 @@
-{%- macro sqlserver__week_of_year(date) -%}
+{%- macro synapse__week_of_year(date) -%}
 cast({{ dbt_date.date_part('week', date)}} as {{ dbt.type_int() }})
 {%- endmacro %}

--- a/macros/dbt_date/calendar_date/week_start.sql
+++ b/macros/dbt_date/calendar_date/week_start.sql
@@ -1,4 +1,4 @@
-{%- macro sqlserver__week_start(date) -%}
+{%- macro synapse__week_start(date) -%}
 -- Sunday as week start date
 cast({{ dbt.dateadd('day', -1, dbt.date_trunc('week', dbt.dateadd('day', 1, date))) }} as date)
 {%- endmacro %}

--- a/macros/dbt_expectations/math/log_natural.sql
+++ b/macros/dbt_expectations/math/log_natural.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__log_natural(x) %}
+{% macro synapse__log_natural(x) %}
 
     log({{ x }})
 

--- a/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
+++ b/macros/dbt_expectations/schema_tests/_generalized/equal_expression.sql
@@ -1,4 +1,4 @@
-{%- macro sqlserver__get_select(model, expression, row_condition, group_by) %}
+{%- macro synapse__get_select(model, expression, row_condition, group_by) %}
     select
         {# {%- if group_by %} #}
             {% for g in group_by or [] -%}
@@ -22,7 +22,7 @@
     {% endif %}
 {% endmacro -%}
 
-{%- macro sqlserver__test_equal_expression(model, expression,
+{%- macro synapse__test_equal_expression(model, expression,
                                 compare_model,
                                 compare_expression,
                                 group_by,

--- a/macros/dbt_expectations/schema_tests/_generalized/expression_is_true.sql
+++ b/macros/dbt_expectations/schema_tests/_generalized/expression_is_true.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__expression_is_true(model, expression, test_condition, group_by_columns, row_condition) %}
+{% macro synapse__expression_is_true(model, expression, test_condition, group_by_columns, row_condition) %}
 
 {% if test_condition == "= true" %}
   {% set test_condition = "= 1" %}

--- a/macros/dbt_expectations/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
+++ b/macros/dbt_expectations/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_expect_column_most_common_value_to_be_in_set(model, column_name,
+{% macro synapse__test_expect_column_most_common_value_to_be_in_set(model, column_name,
                                                             value_set,
                                                             top_n,
                                                             quote_values=False,

--- a/macros/dbt_expectations/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
+++ b/macros/dbt_expectations/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_expect_column_stdev_to_be_between(model, column_name,
+{% macro synapse__test_expect_column_stdev_to_be_between(model, column_name,
                                                     min_value,
                                                     max_value,
                                                     group_by,

--- a/macros/dbt_expectations/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/dbt_expectations/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -10,7 +10,7 @@ coalesce({{ metric_column }}, 0)
 {%- endmacro -%}
 
 
-{% macro sqlserver__test_expect_column_values_to_be_within_n_moving_stdevs(model,
+{% macro synapse__test_expect_column_values_to_be_within_n_moving_stdevs(model,
                                   column_name,
                                   date_column_name,
                                   group_by,

--- a/macros/dbt_expectations/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
+++ b/macros/dbt_expectations/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
@@ -1,5 +1,5 @@
 
-{% macro sqlserver__test_expect_column_values_to_be_within_n_stdevs(model,
+{% macro synapse__test_expect_column_values_to_be_within_n_stdevs(model,
                                   column_name,
                                   group_by,
                                   sigma_threshold

--- a/macros/dbt_expectations/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
+++ b/macros/dbt_expectations/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_expect_select_column_values_to_be_unique_within_record(model,
+{% macro synapse__test_expect_select_column_values_to_be_unique_within_record(model,
                                                     column_list,
                                                     quote_columns,
                                                     ignore_row_if,

--- a/macros/dbt_expectations/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/dbt_expectations/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_expect_grouped_row_values_to_have_recent_data(model, group_by, timestamp_column, datepart, interval, row_condition=None) %}
+{% macro synapse__test_expect_grouped_row_values_to_have_recent_data(model, group_by, timestamp_column, datepart, interval, row_condition=None) %}
 with latest_grouped_timestamps as (
 
     select

--- a/macros/dbt_utils/cross_db_utils/width_bucket.sql
+++ b/macros/dbt_utils/cross_db_utils/width_bucket.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__width_bucket(expr, min_value, max_value, num_buckets) -%}
+{% macro synapse__width_bucket(expr, min_value, max_value, num_buckets) -%}
 
     {% set bin_size -%}
     (( {{ max_value }} - {{ min_value }} ) / {{ num_buckets }} )

--- a/macros/dbt_utils/datetime/date_spine.sql
+++ b/macros/dbt_utils/datetime/date_spine.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__date_spine_sql(datepart, start_date, end_date) %}
+{% macro synapse__date_spine_sql(datepart, start_date, end_date) %}
 
 
     with
@@ -86,7 +86,7 @@
 {% endmacro %}
 
 
-{% macro sqlserver__date_spine(datepart, start_date, end_date) -%}
+{% macro synapse__date_spine(datepart, start_date, end_date) -%}
 
     {% set date_spine_query %}
 

--- a/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_old_relations.sql
@@ -1,6 +1,6 @@
 -- Tidyed up version of Jacob Matson's contribution in the dbt-sqlserver slack channel https://app.slack.com/client/T0VLPD22H/CMRMDDQ9W/thread/CMRMDDQ9W-1625096967.079800 
 
-{% macro sqlserver__drop_old_relations(dry_run='false') %}
+{% macro synapse__drop_old_relations(dry_run='false') %}
     {% if execute %}
         {% set current_models = [] %}
         {% for node in graph.nodes.values()|selectattr("resource_type", "in", ["model", "seed", "snapshot"])%}

--- a/macros/dbt_utils/schema_cleanup/drop_schema_by_name.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_schema_by_name.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__drop_schema_by_name(schema_name) %}
+{% macro synapse__drop_schema_by_name(schema_name) %}
     {% set relation = api.Relation.create(database=target.database, schema=schema_name) %}
     {% do drop_schema(relation) %}
 {% endmacro %}

--- a/macros/dbt_utils/schema_cleanup/drop_schemas_by_prefixes.sql
+++ b/macros/dbt_utils/schema_cleanup/drop_schemas_by_prefixes.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__drop_schemas_by_prefixes(prefixes) %}
+{% macro synapse__drop_schemas_by_prefixes(prefixes) %}
     {# Ensure input is a list to iterate later #}
     {% set prefix_list = [prefixes] if prefixes is string else prefixes %}
 
@@ -19,7 +19,7 @@
             {# Drop each found schema #}
             {% for schema_name in schema_names %}
                 {% do log('Dropping schema ' + schema_name, info=True) %}
-                {% do sqlserver__drop_schema_by_name(schema_name) %}
+                {% do synapse__drop_schema_by_name(schema_name) %}
             {% endfor %}
         {% endif %}
     {% endfor %}

--- a/macros/dbt_utils/schema_tests/mutually_exclusive_ranges.sql
+++ b/macros/dbt_utils/schema_tests/mutually_exclusive_ranges.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_mutually_exclusive_ranges(model, lower_bound_column, upper_bound_column, partition_by=None, gaps='allowed', zero_length_range_allowed=False) %}
+{% macro synapse__test_mutually_exclusive_ranges(model, lower_bound_column, upper_bound_column, partition_by=None, gaps='allowed', zero_length_range_allowed=False) %}
 
 {% if gaps == 'not_allowed' %}
     {% set allow_gaps_operator='=' %}
@@ -73,7 +73,7 @@ calc as (
         coalesce(
             upper_bound {{ allow_gaps_operator }} next_lower_bound,
             is_last_record,
-            false
+            1
         ) as upper_bound_{{ allow_gaps_operator_in_words }}_next_lower_bound
 
     from window_functions

--- a/macros/dbt_utils/schema_tests/relationships_where.sql
+++ b/macros/dbt_utils/schema_tests/relationships_where.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_relationships_where(model, column_name, to, field, from_condition, to_condition) %}
+{% macro synapse__test_relationships_where(model, column_name, to, field, from_condition, to_condition) %}
 
   {# override dbt-utils' integration tests args default see: #}
   {# https://github.com/fishtown-analytics/dbt-utils/blob/bbba960726667abc66b42624f0d36bbb62c37593/integration_tests/models/schema_tests/schema.yml#L67-L75 #}

--- a/macros/dbt_utils/schema_tests/sequential_values.sql
+++ b/macros/dbt_utils/schema_tests/sequential_values.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_sequential_values(model, column_name, interval=1, datepart=None) %}
+{% macro synapse__test_sequential_values(model, column_name, interval=1, datepart=None) %}
 
     select
         *

--- a/macros/dbt_utils/schema_tests/test_not_null_where.sql
+++ b/macros/dbt_utils/schema_tests/test_not_null_where.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_not_null_where(model, column_name) %}
+{% macro synapse__test_not_null_where(model, column_name) %}
 
   {% set where = kwargs.get('where', kwargs.get('arg')) %}
   {# override dbt-utils' integration tests args default see: #}

--- a/macros/dbt_utils/schema_tests/test_unique_where.sql
+++ b/macros/dbt_utils/schema_tests/test_unique_where.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__test_unique_where(model, column_name) %}
+{% macro synapse__test_unique_where(model, column_name) %}
   {% set where = kwargs.get('where', kwargs.get('arg')) %}
   {# override dbt-utils' integration tests args default see: #}
   {# https://github.com/fishtown-analytics/dbt-utils/blob/bbba960726667abc66b42624f0d36bbb62c37593/integration_tests/models/schema_tests/schema.yml#L53-L65 #}

--- a/macros/dbt_utils/sql/deduplicate.sql
+++ b/macros/dbt_utils/sql/deduplicate.sql
@@ -2,7 +2,7 @@
 -- This seems to be the best way to do the deduplication in TSQL without introducing
 -- a new column for the row number.
 #}
-{%- macro sqlserver__deduplicate(relation, partition_by, order_by) -%}
+{%- macro synapse__deduplicate(relation, partition_by, order_by) -%}
 
     select top 1 with ties
         *

--- a/macros/dbt_utils/sql/generate_series.sql
+++ b/macros/dbt_utils/sql/generate_series.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__generate_series(upper_bound) %}
+{% macro synapse__generate_series(upper_bound) %}
 
     {% set n = dbt_utils.get_powers_of_two(upper_bound) %}
 

--- a/macros/dbt_utils/sql/generate_surrogate_key.sql
+++ b/macros/dbt_utils/sql/generate_surrogate_key.sql
@@ -1,0 +1,29 @@
+{%- macro sqlserver__generate_surrogate_key(field_list) -%}
+
+{%- if var('surrogate_key_treat_nulls_as_empty_strings', False) -%}
+    {%- set default_null_value = "" -%}
+{%- else -%}
+    {%- set default_null_value = '_dbt_utils_surrogate_key_null_' -%}
+{%- endif -%}
+
+{%- set fields = [] -%}
+
+{%- for field in field_list -%}
+
+    {%- do fields.append(
+        "coalesce(cast(" ~ field ~ " as " ~ dbt.type_string() ~ "), '" ~ default_null_value  ~"')"
+    ) -%}
+
+    {%- if not loop.last %}
+        {%- do fields.append("'-'") -%}
+    {%- endif -%}
+
+{%- endfor -%}
+
+{%- if fields|length > 1 %}
+    {{ dbt.hash(dbt.concat(fields)) }}
+{%- else -%}
+    {{ dbt.hash(fields[0]) }}
+{%- endif -%}
+
+{%- endmacro -%}

--- a/macros/dbt_utils/sql/generate_surrogate_key.sql
+++ b/macros/dbt_utils/sql/generate_surrogate_key.sql
@@ -1,4 +1,4 @@
-{%- macro sqlserver__generate_surrogate_key(field_list) -%}
+{%- macro synapse__generate_surrogate_key(field_list) -%}
 
 {%- if var('surrogate_key_treat_nulls_as_empty_strings', False) -%}
     {%- set default_null_value = "" -%}

--- a/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
+++ b/macros/dbt_utils/sql/get_tables_by_pattern_sql.sql
@@ -1,4 +1,4 @@
-{% macro sqlserver__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+{% macro synapse__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
         SELECT DISTINCT
             table_schema AS "table_schema",


### PR DESCRIPTION
Upgrading our dbt to 1.7 leads to not picking up the macro's in this project. To make sure that they are picked up by dbt, we have to change the adapter names to match the synapse adapter.